### PR TITLE
Support for custom props & parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea/

--- a/index.js
+++ b/index.js
@@ -3,15 +3,67 @@
 var v8StyleErrors = require('./lib/v8-style')()
 var reformat = require('./lib/reformat')
 
-function ErrorMaker(name, ParentError) {
-  function NewError(message) {
-    if (!(this instanceof NewError))
-      return new NewError(message)
+// quick shim for Object.assign, thanks @WebReflection
+// https://gist.github.com/WebReflection/10404826
+if (!('assign' in Object)) {
+  Object.assign = function(has){
+    'use strict';
+    return assign;
+    function assign(target, source) {
+      for (var i = 1; i < arguments.length; i++) {
+        copy(target, arguments[i]);
+      }
+      return target;
+    }
+    function copy(target, source) {
+      for (var key in source) {
+        if (has.call(source, key)) {
+          target[key] = source[key];
+        }
+      }
+    }
+  }({}.hasOwnProperty);
+}
+
+/**
+ *
+ * @param name {string} Name of the error
+ * @param ParentError {Error} Parent of this error
+ * @param options {object} Any additional options. Add a properties key to set fixed props on the prototype. Add a params key to allow extra parameters to be defined.
+ * @returns {NewError}
+ * @constructor
+ *
+ * Example:
+ *
+ * var MyError = error('MyError', Error, {props: {code: '500'}, params: ['customProperty']})
+ *
+ * throw new MyError('custom property value', 'Message')
+ *
+ *
+ */
+function ErrorMaker(name, ParentError, options) {
+  if (!options) options = {}
+
+  function NewError() {
+
+    // convert arguments to array. strictly not necessary but it's an old habit
+    var args = [].slice.call(arguments)
+
+    if (!(this instanceof NewError)) {
+      return construct(NewError, args)
+    }
+
+    // set all custom defined parameters, then the message
+    for (var i=0; i<this.params.length;i++) {
+      this[this.params[i]] = args.shift()
+    }
+    var message = args.shift()
 
     // Use a try/catch block to capture the stack trace. Capturing the stack trace here is
     // necessary, otherwise we will get the stack trace at the time the new error class was created,
     // rather than when it is instantiated.  We add `message` and `name` so that the stack trace
     // string will match our current error class.
+
     try {
       throw new Error(message)
     }
@@ -30,6 +82,17 @@ function ErrorMaker(name, ParentError) {
   }
 
   NewError.prototype = new (ParentError || Error)()
+
+  // set custom parameters into the prototype for processing at construction time
+  if (options.params && options.params.constructor === Array) {
+    NewError.prototype.params = options.params
+  } else {
+    NewError.prototype.params = []
+  }
+
+  // set custom properties (fixed)
+  if (options.props) Object.assign(NewError.prototype,options.props)
+
   NewError.prototype.constructor = NewError
   NewError.prototype.inspect = function() {
     return this.message
@@ -40,5 +103,15 @@ function ErrorMaker(name, ParentError) {
 
   return NewError
 }
+
+function construct(constructor, args) {
+  function F() {
+    return constructor.apply(this, args);
+  }
+  F.prototype = constructor.prototype;
+  return new F();
+}
+
+
 
 module.exports = ErrorMaker

--- a/index.js
+++ b/index.js
@@ -59,18 +59,8 @@ function ErrorMaker(name, ParentError, options) {
     }
     var message = args.shift()
 
-    // Use a try/catch block to capture the stack trace. Capturing the stack trace here is
-    // necessary, otherwise we will get the stack trace at the time the new error class was created,
-    // rather than when it is instantiated.  We add `message` and `name` so that the stack trace
-    // string will match our current error class.
-
-    try {
-      throw new Error(message)
-    }
-    catch (err) {
-      err.name = name
-      this.stack = err.stack
-    }
+    // capture stack trace - polyfill used
+    this.captureStackTrace()
 
     // if we have v8-styled stack messages, then reformat
     if (v8StyleErrors) {
@@ -100,6 +90,18 @@ function ErrorMaker(name, ParentError, options) {
       : '[' + name + ']'
   }
   NewError.prototype.name = name
+  // helper and polyfill for setting the stack trace
+  NewError.prototype.captureStackTrace = function () {
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+    else {
+      var stackKeeper = new Error();
+      var self = this;
+      stackKeeper.toString = function () { return self.toString(); };
+      this._stackKeeper = stackKeeper;
+    }
+  };
 
   return NewError
 }

--- a/test/options.js
+++ b/test/options.js
@@ -1,0 +1,66 @@
+'use strict';
+
+var test = require('tape')
+var error = require('../')
+
+test('params', function(t) {
+    t.plan(3)
+
+    var MyError = error('MyError', Error, {params: ['test']})
+
+    try {
+        throw MyError('testing','faffy')
+    }
+    catch (err) {
+        t.equals(err.name, 'MyError', 'should set error name correctly')
+        t.equals(err.message, 'faffy', 'should set error message correctly')
+        t.equals(err.test, 'testing', 'should set custom parameter correctly')
+    }
+})
+
+test('params without message', function(t) {
+    t.plan(3)
+
+    var MyError = error('MyError', Error, {params: ['test']})
+
+    try {
+        throw MyError('testing','')
+    }
+    catch (err) {
+        t.equals(err.name, 'MyError', 'should set error name correctly')
+        t.equals(err.message, '', 'should set error message correctly')
+        t.equals(err.test, 'testing', 'should set custom parameter correctly')
+    }
+})
+
+test('params without message', function(t) {
+    t.plan(4)
+
+    var MyError = error('MyError', Error, {params: ['test', 'test2']})
+
+    try {
+        throw MyError('testing',undefined,'messageme')
+    }
+    catch (err) {
+        t.equals(err.name, 'MyError', 'should set error name correctly')
+        t.equals(err.message, 'messageme', 'should set error message correctly')
+        t.equals(err.test, 'testing', 'should set parameter correctly')
+        t.equals(err.test2, undefined, 'should set parameter correctly')
+    }
+})
+
+test('properties', function(t) {
+    t.plan(3)
+
+    var MyError = error('MyError', Error, {props: {code: '500'}})
+
+    try {
+        throw MyError('faffy')
+    }
+    catch (err) {
+        t.equals(err.name, 'MyError', 'should set error name correctly')
+        t.equals(err.message, 'faffy', 'should set error message correctly')
+        t.equals(err.code, '500', 'should set custom property correctly')
+    }
+})
+


### PR DESCRIPTION
Per issue #3 with a little sugar on top: Added support for custom parameters (to be used when throwing the error) and default properties on the error (eg an error code). Test suite expanded to also cover these cases.

* Custom parameters (set via ```params```) allow you to expand the type signature for the function, ie create the error with extra parameters that are automatically set.
* Default properties are set on the prototype (via ```props```).

Settings are provided optionally in an object following the message parameter.

Example usage:
```
var MyError = error('MyError', Error, {props: {code: '500'}, params: ['customProperty']})

var error = new MyError('custom property value', 'Message')
// error.code === '500' (set on prototype)
// error.customProperty === 'custom property value' (set on instance)
```

Notes: 
* I did not set any guards against overwriting existing error properties. This might be something to add in the future.
* Did not yet update the documentation as I expect you may have some feedback. ;-)

Up to you to accept, we needed this for our use case and I am fine with it as is. If you have any remarks let me know (eg props vs params might be confusing, suggestions welcome) - I'm overloaded with work but if the request is small i'll fix things right up.